### PR TITLE
Add build files to npm release

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,5 +8,4 @@ exclude_paths:
   - "karma.config.js"
   - "webpack.config.js"
   - "test/*"
-  - "push-state-tree.js"
-  - "push-state-tree.min.js"
+  - "build/*"

--- a/.npmignore
+++ b/.npmignore
@@ -62,4 +62,10 @@ npm-debug.log
 .c9revisions
 .settings
 
-build/
+.travis.yml
+.codeclimate.yml
+.editorconfig
+demo/
+index.html
+favicon.ico
+build/coverage/

--- a/.npmignore
+++ b/.npmignore
@@ -63,7 +63,6 @@ npm-debug.log
 .settings
 
 .travis.yml
-.codeclimate.yml
 .editorconfig
 demo/
 index.html

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "scripts": {
     "start": "karma start --watch",
     "quick-start": "karma start --watch --fast-build",
-    "prepublish": "npm run build",
     "preversion": "npm run build",
     "build": "karma start && webpack --publish",
     "test": "karma start"


### PR DESCRIPTION
Add a `npmignore` file to the npm release ignore the `gitignore` file and include the builded version of files in the release.
