### PR TITLE
Fix karma execution to ignore esLint loader and apply istanbul before run babel

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -117,7 +117,7 @@ module.exports = function (config) {
     webpack: {
       // Create a literal object for the module to not change how webpack-dev-server load the modules
       module: Object.assign({}, webpackConfig.module, {
-        postLoaders: [{
+        preLoaders: [{
           test: /\.js/,
           exclude: /(test|node_modules|bower_components|\.shim\.js$|\.json$)/,
           loader: 'istanbul-instrumenter'

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -62,6 +62,7 @@ if (WATCH) {
   delete webpackDevConfig.output.library;
   delete webpackDevConfig.output.libraryTarget;
   delete webpackDevConfig.output.umdNamedDefine;
+  webpackDevConfig.module.preLoaders = [];
 
   var compiler = webpack(webpackDevConfig);
   var server = new webpackDevServer(compiler, {
@@ -117,11 +118,14 @@ module.exports = function (config) {
     webpack: {
       // Create a literal object for the module to not change how webpack-dev-server load the modules
       module: Object.assign({}, webpackConfig.module, {
-        preLoaders: [{
-          test: /\.js/,
-          exclude: /(test|node_modules|bower_components|\.shim\.js$|\.json$)/,
-          loader: 'istanbul-instrumenter'
-        }]
+        preLoaders: [
+          {
+            test: /\.js/,
+            exclude: /(test|node_modules|bower_components|\.shim\.js$|\.json$)/,
+            loader: 'istanbul-instrumenter'
+          },
+          ...webpackConfig.module.preLoaders
+        ]
       }),
       plugins: webpackConfig.plugins,
       bail: !WATCH,


### PR DESCRIPTION
Karma was displaying as code coverage the result of code after run babel, because istanbul was a postLoader, with this change, it executes instabul before babel, making the code-coverage generated be the same as the source-code.

Also doing this I removed the esLint execution from tests, this improves the build performance. The esLint are still executed but only once now on the live server generation.
